### PR TITLE
会員登録バリデーションの変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,9 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :pets, allow_destroy: true, reject_if: :all_blank
 
   validates :name, presence: true, length: { maximum: 255 }
-  validates :email, presence: true, uniqueness: true
-  validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+  validates :email, uniqueness: { case_sensitive: false }, presence: true, format: { with: VALID_EMAIL_REGEX }
+  validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :reset_password_token, uniqueness: true, allow_nil: true

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -4,6 +4,8 @@
   <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
     <div class="mb-10 md:mb-16">
       <h2 class="mb-4 text-center text-2xl font-bold md:mb-6 lg:text-3xl"><%= t('.title') %></h2>
+
+      <p class="mb-4 text-center md:mb-6">(*は必須項目です)</p>
     </div>
 
     <%= form_with model: @user, class: 'mx-auto grid max-w-screen-md gap-4 sm:grid-cols-2' do |f| %>
@@ -15,22 +17,22 @@
       </div>
 
       <div class="sm:col-span-2">
-        <%= f.label :name, class: 'mb-2 inline-block text-sm sm:text-base' %>
+        <%= f.label :name, class: 'mb-2 inline-block text-sm sm:text-base' %>*
         <%= f.text_field :name, class: 'w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition duration-100 focus:ring' %>
       </div>
 
       <div class="sm:col-span-2">
-        <%= f.label :email, class: 'mb-2 inline-block text-sm sm:text-base' %>
-        <%= f.email_field :email, class: 'w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition duration-100 focus:ring' %>
+        <%= f.label :email, class: 'mb-2 inline-block text-sm sm:text-base' %>*
+        <%= f.email_field :email, class: 'w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition duration-100 focus:ring', placeholder: '正しいメールアドレスを入力してください' %>
       </div>
 
       <div class="sm:col-span-2">
-        <%= f.label :password, class: 'mb-2 inline-block text-sm sm:text-base' %>
-        <%= f.password_field :password, class: 'w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition duration-100 focus:ring' %>
+        <%= f.label :password, class: 'mb-2 inline-block text-sm sm:text-base' %>*
+        <%= f.password_field :password, class: 'w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition duration-100 focus:ring', placeholder: '6文字以上で入力してください' %>
       </div>
 
       <div class="sm:col-span-2">
-        <%= f.label :password_confirmation, class: 'mb-2 inline-block text-sm sm:text-base' %>
+        <%= f.label :password_confirmation, class: 'mb-2 inline-block text-sm sm:text-base' %>*
         <%= f.password_field :password_confirmation, class: 'w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition duration-100 focus:ring' %>
       </div>
 


### PR DESCRIPTION
 - メールアドレスを正しいフォーマットでのみ許可する
 - パスワードに必要な文字数を3文字 -> 6文字に変更