### PR TITLE
投稿に関連するペットの追加・編集・削除機能の実装

### DIFF
--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -2,6 +2,8 @@ class Pet < ApplicationRecord
   mount_uploader :pet_avatar, PetAvatarUploader
 
   belongs_to :user
+  has_many :post_pets, dependent: :destroy
+  has_many :posts, through: :post_pets
 
   enum gender: { male: 0, female: 1 }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,6 +7,8 @@ class Post < ApplicationRecord
   has_many :liked_users, through: :likes, source: :user
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
+  has_many :post_pets, dependent: :destroy
+  has_many :pets, through: :post_pets
 
   validates :post_image, presence: true
   validates :title, presence: true, length: { maximum: 255 }

--- a/app/models/post_pet.rb
+++ b/app/models/post_pet.rb
@@ -1,0 +1,8 @@
+class PostPet < ApplicationRecord
+  belongs_to :post
+  belongs_to :pet
+
+  validates :post_id, presence: true
+  validates :pet_id, presence: true
+  validates :pet_id, uniqueness: { scope: :post_id }
+end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -16,6 +16,21 @@
     <%= f.text_area :body, class: 'w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition duration-100 focus:ring', placeholder: '写真の説明を入力してください' %>
   </div>
 
+  <div class="sm:col-span-2">
+    <h3>ペットを選択</h3>
+    <% if current_user.pets.any? %>
+      <% pets.each do |pet| %>
+        <div>
+          <%= check_box_tag "post[pet_ids][]", pet.id %>
+          <%= image_tag pet.pet_avatar.url, class: 'rounded-full w-20 h-20' %>
+          <%= pet.name %>
+        </div>
+      <% end %>
+    <% else %>
+      プロフィールからペットを登録すると、選択できるようになります。
+    <% end %>
+  </div>
+
   <%= f.fields_for :tags do |i| %>
     <div class="sm:col-span-2">
       <%= i.label :name, t('defaults.tag'), class: 'mb-2 inline-block text-sm sm:text-base' %>

--- a/app/views/posts/_form_with_title.html.erb
+++ b/app/views/posts/_form_with_title.html.erb
@@ -21,6 +21,21 @@
     <%= f.text_area :body, class: 'w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition duration-100 focus:ring', row: '10', style: 'height: 200px' %>
   </div>
 
+  <div class="sm:col-span-2">
+    <h3>ペットを選択</h3>
+    <% if current_user.pets.any? %>
+      <% pets.each do |pet| %>
+        <div>
+          <%= check_box_tag "post[pet_ids][]", pet.id, post.pets.include?(pet) %>
+          <%= image_tag pet.pet_avatar.url, class: 'rounded-full w-20 h-20' %>
+          <%= pet.name %>
+        </div>
+      <% end %>
+    <% else %>
+      プロフィールからペットを登録すると、選択できるようになります。
+    <% end %>
+  </div>
+
   <%= f.fields_for :tags do |i| %>
     <div class="sm:col-span-2">
       <%= i.label :name, t('defaults.tag'), class: 'mb-2 inline-block text-sm sm:text-base' %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -8,6 +8,6 @@
       <h2 class="mb-4 text-center text-2xl font-bold md:mb-6 lg:text-3xl"><%= t('.title') %></h2>
     </div>
 
-    <%= render 'form_with_title', post: @post %>
+    <%= render 'form_with_title', post: @post, pets: @pets %>
   </div>
 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -10,6 +10,6 @@
       <p class="mb-4 text-center md:mb-6"><strong>1日3回</strong>まで投稿できます</p>
     </div>
 
-    <%= render 'form', post: @post %>
+    <%= render 'form', post: @post, pets: @pets %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -39,6 +39,18 @@
       <p><%= simple_format(@post.body) %></p>
     </div>
 
+    <% if @post.pets.any? %>
+      <h2>関連するペット</h2>
+      <ul>
+        <% @post.pets.each do |pet| %>
+          <li>
+            <%= image_tag pet.pet_avatar.url, class: 'rounded-full w-20 h-20' %>
+            <div class="text-gray-300"><%= pet.name %></div>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
     <% if @tags.present? %>
       <div class="flex justify-center card-footer my-10 gap-2">
         <% @tags.each do |tag| %>

--- a/db/migrate/20240905023232_create_post_pets.rb
+++ b/db/migrate/20240905023232_create_post_pets.rb
@@ -1,0 +1,12 @@
+class CreatePostPets < ActiveRecord::Migration[7.0]
+  def change
+    create_table :post_pets do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :pet, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :post_pets, [:post_id, :pet_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_18_135823) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_05_023232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_18_135823) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_pets_on_user_id"
+  end
+
+  create_table "post_pets", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "pet_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["pet_id"], name: "index_post_pets_on_pet_id"
+    t.index ["post_id", "pet_id"], name: "index_post_pets_on_post_id_and_pet_id", unique: true
+    t.index ["post_id"], name: "index_post_pets_on_post_id"
   end
 
   create_table "post_tags", force: :cascade do |t|
@@ -118,6 +128,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_18_135823) do
   add_foreign_key "notifications", "users", column: "recipient_id"
   add_foreign_key "notifications", "users", column: "sender_id"
   add_foreign_key "pets", "users"
+  add_foreign_key "post_pets", "pets"
+  add_foreign_key "post_pets", "posts"
   add_foreign_key "post_tags", "posts"
   add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"


### PR DESCRIPTION
- 事故画投稿フォームにて、登録済みのペットから関連する子を選択できる機能を実装
- 選択されたペット情報を事故画詳細ページにて表示する
- 投稿フォームでペット未選択の場合、ペット情報は非表示で投稿される
- 投稿した事故画において、関連するペットの追加、変更および削除できる機能を実装